### PR TITLE
0.3.0: ~150x faster reads, decoded keys, CRC verification, JSON CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ and the format of [keepachangelog.com](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-22
+
+### Performance
+- **~150× faster reads.** The internal record reads no longer go
+  through `octet`'s protocol-dispatch path — `zip-meta`, `zip-entries`,
+  `zip-comment`, and `scan-local-headers` now use hand-rolled
+  `ByteBuffer.getInt` / `.getShort` readers. On clojure-1.12.0.jar
+  (3 770 entries):
+  - `zip-meta` (full): 1 893 ms → 25 ms (with the new decoded keys)
+                                / 12 ms (raw)
+  - `zip-meta` (CDR only): 1 198 ms → 14 ms / 5 ms
+  - `zip-entries`: 1 225 ms → 18 ms
+- Hand-rolled writers replace `octet` on the repair path too
+  (`repair-zip-with-preamble-bytes`, `rebuild-central-directory!`,
+  `set-zip-comment!`). Octet remains as a dependency only for the
+  legacy public `read-spec-from-*` / `write-spec-to-*` wrappers.
+- A `bench/clj_zip_meta/bench.clj` namespace runs criterium
+  quick-benches against the hot paths. Invoke via `lein bench` or
+  `clj -M:bench`.
+
+### Added
+- **Decoded convenience keys** on every record (opt out with
+  `{:decode false}`):
+  - `:last-modified` — `java.time.LocalDateTime`.
+  - `:dos-attributes` — set decoded from the low byte of
+    `:external-file-attributes` (CDR only).
+  - `:unix-mode` — Unix file mode (octal) from the upper 16 bits of
+    `:external-file-attributes`, when `:version-made-by` indicates
+    Unix host. `nil` otherwise.
+  - `:directory?`, `:encrypted?`, `:utf8-name?` — booleans derived
+    from `:general-purpose` and the file name.
+  - `:extra-fields` — parsed TLV vector. Each entry has `:tag`,
+    `:tag-name`, `:size`, `:data`. Tag `0x5455` (extended-timestamp)
+    additionally carries a decoded `:decoded` map.
+- **CRC-32 verification** of entry contents:
+  - `verify-crcs` — read every entry's compressed data, decompress
+    (STORED and DEFLATE), and compare against the recorded CRC-32.
+  - `verify-crcs-summary` — folds the per-entry results into status
+    counts plus mismatches / errors / aggregate `:valid?`.
+  - `validate-zip-meta` accepts `:verify-crcs true` to roll CRC
+    failures into its existing `:issues` vector.
+- `find-entry` — look up the compact summary for one entry by name.
+- `zip-meta` accepts `{:include-locals false}` to skip reading the
+  per-entry local file headers.
+- **`deps.edn`** manifest with `:test`, `:cli`, and `:bench` aliases
+  for tools.deps users.
+- **CLI** gains a `verify` command, a `--crc` flag on `validate`, a
+  `--json` flag on every read-only command (with an inline JSON
+  emitter — no new dependency), and a `--version` flag.
+
+### Changed
+- Bumped library version to 0.3.0.
+- `dump-sig-number` now emits the on-disk little-endian byte order
+  so the result actually matches what a hex dump shows.
+
 ## [0.2.0] - 2026-05-22
 
 ### Added
@@ -70,7 +125,8 @@ and the format of [keepachangelog.com](https://keepachangelog.com/).
   local file headers from zip/jar files; repair offsets after prepending
   preamble bytes.
 
-[Unreleased]: https://github.com/mbjarland/clj-zip-meta/compare/0.2.0...HEAD
+[Unreleased]: https://github.com/mbjarland/clj-zip-meta/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/mbjarland/clj-zip-meta/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/mbjarland/clj-zip-meta/compare/0.1.3...0.2.0
 [0.1.3]: https://github.com/mbjarland/clj-zip-meta/compare/0.1.2...0.1.3
 [0.1.2]: https://github.com/mbjarland/clj-zip-meta/compare/0.1.0...0.1.2

--- a/README.md
+++ b/README.md
@@ -15,16 +15,24 @@ data; for that, use `java.util.zip.ZipFile` or libraries built on it.
 ## What it gives you
 
 * `zip-meta` — read every record in an archive and return it as a
-  plain Clojure map.
+  plain Clojure map. ~150× faster than the previous octet-based path
+  on realistic-size jars; records come with decoded convenience keys
+  (`:last-modified`, `:unix-mode`, `:dos-attributes`, `:directory?`,
+  `:encrypted?`, `:utf8-name?`, `:extra-fields`).
 * `zip-entries` — fast, CDR-only entry listing.
 * `find-entry` — look up an entry by name.
 * `zip-comment` / `set-zip-comment!` — read or rewrite the archive
   comment.
 * `summarize` — high-level statistics in a single map.
-* `validate-zip-meta` — check the metadata for self-consistency.
+* `validate-zip-meta` — check the metadata for self-consistency,
+  optionally including a CRC-32 pass over every entry's payload.
+* `verify-crcs` / `verify-crcs-summary` — decompress every entry and
+  check the data against its recorded CRC-32. The strongest integrity
+  check the library offers.
 * `repair-zip` — fix prepended-byte offset drift, strip preambles,
   or **rebuild a missing central directory from local file headers**.
-* A `lein run` CLI for the same operations from the shell.
+* A `lein run` CLI for the same operations from the shell, with
+  `--json` output for piping to `jq` or other tools.
 
 ## Why?
 
@@ -46,13 +54,22 @@ zip tools; `clj-zip-meta` repairs it.
 Leiningen / Boot:
 
 ```clojure
-[clj-zip-meta/clj-zip-meta "0.2.0"]
+[clj-zip-meta/clj-zip-meta "0.3.0"]
 ```
 
 deps.edn:
 
 ```clojure
-clj-zip-meta/clj-zip-meta {:mvn/version "0.2.0"}
+clj-zip-meta/clj-zip-meta {:mvn/version "0.3.0"}
+```
+
+The repo also ships a `deps.edn` with `:test`, `:cli`, and `:bench`
+aliases so contributors can work with tools.deps directly:
+
+```
+clj -M:test                    # run the test suite
+clj -M:cli -- list my.jar      # run the CLI
+clj -M:bench [PATH-TO-A-JAR]   # criterium benchmarks
 ```
 
 Requires Clojure 1.10+ and JDK 11+.
@@ -67,13 +84,18 @@ Requires Clojure 1.10+ and JDK 11+.
 
 ```clojure
 (z/zip-entries "my.jar")
-;;=> [{:file-name "META-INF/MANIFEST.MF"
-;;     :file-comment ""
-;;     :compressed-size 125
-;;     :uncompressed-size 167
-;;     :crc-32 -2096663765
+;;=> [{:file-name          "META-INF/MANIFEST.MF"
+;;     :file-comment       ""
+;;     :compressed-size    125
+;;     :uncompressed-size  167
+;;     :crc-32             -2096663765
 ;;     :compression-method 8
-;;     :offset 2286}
+;;     :offset             2286
+;;     :last-modified      #object[LocalDateTime "2024-09-05T19:05:00"]
+;;     :directory?         false
+;;     :encrypted?         false
+;;     :unix-mode          0100644
+;;     :dos-attributes     #{}}
 ;;    ...]
 
 (z/find-entry "my.jar" "META-INF/MANIFEST.MF")
@@ -86,6 +108,12 @@ Requires Clojure 1.10+ and JDK 11+.
 ;;    :total-uncompressed 5421
 ;;    :zip-comment ""}
 ```
+
+The raw on-disk fields (e.g. `:last-mod-file-time`,
+`:external-file-attributes`) are still present in `zip-meta`'s
+record maps — the decoded keys (`:last-modified`, `:unix-mode`,
+`:dos-attributes`, …) are layered on top. Pass `{:decode false}` to
+skip the decoration step when only the raw integers matter.
 
 ### Full metadata
 
@@ -140,7 +168,31 @@ noticeably faster on large jars:
 ;;=> {:valid? false
 ;;    :issues ["317 extra bytes at beginning or within zipfile"]
 ;;    :extra-bytes 317}
+
+;; Optionally include a CRC-32 pass over every entry's data:
+(z/validate-zip-meta "my.jar" :verify-crcs true)
 ```
+
+### CRC verification
+
+`verify-crcs` reads each entry's compressed payload, decompresses
+it, and compares the resulting CRC-32 against the value recorded
+in the central directory. It supports the STORED (0) and DEFLATE
+(8) compression methods — every jar and the vast majority of zips.
+
+```clojure
+(z/verify-crcs "my.jar")
+;;=> [{:file-name "META-INF/" :status :empty   :recorded-crc 0}
+;;    {:file-name "Foo.class" :status :ok      :recorded-crc -123 :computed-crc 4294967173}
+;;    {:file-name "Bar.class" :status :mismatch :recorded-crc 42  :computed-crc 99}]
+
+(z/verify-crcs-summary "my.jar")
+;;=> {:total 3 :counts {:empty 1 :ok 1 :mismatch 1}
+;;    :mismatches [{...}] :errors [] :valid? false}
+```
+
+This is the strongest integrity check the library performs — it
+verifies the data itself, not just the metadata.
 
 ### Repair
 
@@ -202,21 +254,33 @@ The library doubles as a CLI through `lein run`:
 
 ```
 $ lein run -- list my.jar
-    compressed   uncompressed name
-    ----------   ------------ ----
-             0              0 META-INF/
-           125            167 META-INF/MANIFEST.MF
-           412           1024 my/Foo.class
-$ lein run -- summary my.jar
-$ lein run -- validate my.jar
-$ lein run -- repair broken.jar
-$ lein run -- repair with-prelude.jar --strip
-$ lein run -- comment my.jar
-$ lein run -- comment my.jar "new archive comment"
+compressed  uncompressed  modified             name
+----------  ------------  --------             ----
+         0             0  2024-09-05T19:05     META-INF/
+       125           167  2024-09-05T19:05     META-INF/MANIFEST.MF
+       412          1024  2024-09-05T19:05     my/Foo.class
+
+$ lein run -- summary  my.jar
+$ lein run -- validate my.jar [--crc]
+$ lein run -- verify   my.jar
+$ lein run -- repair   broken.jar [--strip]
+$ lein run -- comment  my.jar
+$ lein run -- comment  my.jar "new archive comment"
 ```
 
-`lein uberjar` produces a self-contained `clj-zip-meta-<version>-standalone.jar`
-you can ship to a server and invoke with `java -jar`.
+Add `--json` to any read-only command for machine-readable output
+suitable for piping to `jq`:
+
+```
+$ lein run -- list my.jar --json | jq '.[].file-name'
+"META-INF/"
+"META-INF/MANIFEST.MF"
+"my/Foo.class"
+```
+
+`lein uberjar` produces a self-contained
+`clj-zip-meta-<version>-standalone.jar` you can ship to a server and
+invoke with `java -jar`.
 
 ## Detail: the zip data model
 
@@ -254,13 +318,17 @@ binary layer of zip files. Within that scope it is intended for
 production use:
 
 * Test coverage across reading, repairing, rebuilding from local
-  headers, and the CLI.
+  headers, CRC verification, and the CLI.
 * CI matrix across Clojure 1.10 / 1.11 / 1.12 on JDK 11 / 17 / 21.
 * `*warn-on-reflection*` enabled with the project compiling cleanly.
+* Hand-rolled record reader/writer puts the hot path squarely in
+  primitive `ByteBuffer` operations — `zip-meta` on a 4 MB / 3 770-entry
+  jar runs in ~25 ms (decoded) / 12 ms (raw).
 
 Out of scope (no current plans):
 
-* Zip64.
+* Zip64. Archives whose total size or per-entry size exceeds 4 GiB
+  will not round-trip.
 * Reading or decrypting encrypted entries.
 * Extracting entry data (use `java.util.zip.ZipFile`).
 

--- a/bench/clj_zip_meta/bench.clj
+++ b/bench/clj_zip_meta/bench.clj
@@ -1,0 +1,56 @@
+(ns clj-zip-meta.bench
+  "Criterium benchmarks for the hot paths.
+
+  Run with: clj -M:bench [PATH-TO-A-JAR]
+
+  Defaults to whatever clojure-*.jar lives in the local Maven repo so
+  results are reproducible without manual setup."
+  (:require [clj-zip-meta.core :as zm]
+            [criterium.core :as cc]
+            [clojure.java.io :as jio]))
+
+(defn- pick-jar
+  "Find a reasonably sized jar to benchmark against. Tries an explicit
+  CLI argument, then ~/.m2 for an org.clojure/clojure jar, then the
+  tiny bundled good.zip as last resort."
+  [args]
+  (let [explicit (when-let [^String p (first args)]
+                   (let [f (jio/file p)]
+                     (when (.exists f) f)))
+        clj-dir  (jio/file (System/getProperty "user.home")
+                           ".m2/repository/org/clojure/clojure")
+        clj-jar  (when (.isDirectory clj-dir)
+                   (->> (file-seq clj-dir)
+                        (filter #(re-find #"clojure-\d+(?:\.\d+)+\.jar$"
+                                          (.getName ^java.io.File %)))
+                        (sort-by #(.length ^java.io.File %))
+                        last))
+        fallback (jio/file "src/test/resources/good.zip")]
+    (.getAbsolutePath ^java.io.File (or explicit clj-jar fallback))))
+
+(defn -main [& args]
+  (let [jar (pick-jar args)
+        sz  (.length (jio/file jar))
+        n   (count (:cdr-records (zm/zip-meta jar)))]
+    (println (format "Target: %s (%.1f KiB, %d entries)%n" jar (/ sz 1024.0) n))
+
+    (println "== zip-meta (full, decoded) ==")
+    (cc/quick-bench (zm/zip-meta jar))
+
+    (println "== zip-meta (cdr-only, decoded) ==")
+    (cc/quick-bench (zm/zip-meta jar {:include-locals false}))
+
+    (println "== zip-meta (cdr-only, raw) ==")
+    (cc/quick-bench (zm/zip-meta jar {:include-locals false :decode false}))
+
+    (println "== zip-entries ==")
+    (cc/quick-bench (zm/zip-entries jar))
+
+    (println "== zip-comment ==")
+    (cc/quick-bench (zm/zip-comment jar))
+
+    (println "== find-end-of-cdr-offset ==")
+    (cc/quick-bench (zm/find-end-of-cdr-offset jar))
+
+    (println "== verify-crcs ==")
+    (cc/quick-bench (zm/verify-crcs jar))))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,23 @@
+{:paths ["src/main" "src/main/resources"]
+
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        funcool/octet       {:mvn/version "1.1.2"}}
+
+ :aliases
+ {;; clj -M:test
+  :test
+  {:extra-paths ["src/test" "src/test/resources"]
+   :extra-deps  {io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "cognitect.test-runner"
+                 "-d" "src/test"]}
+
+  ;; clj -M:cli -- COMMAND FILE
+  :cli
+  {:main-opts ["-m" "clj-zip-meta.cli"]}
+
+  ;; clj -M:bench
+  :bench
+  {:extra-paths ["bench"]
+   :extra-deps  {criterium/criterium {:mvn/version "0.4.6"}}
+   :main-opts   ["-m" "clj-zip-meta.bench"]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-zip-meta/clj-zip-meta "0.2.0"
+(defproject clj-zip-meta/clj-zip-meta "0.3.0"
   :description "A Clojure library for reading and patching the binary
                 metadata of zip and jar files (local file headers, central
                 directory headers, end-of-central-directory record)."

--- a/project.clj
+++ b/project.clj
@@ -21,9 +21,13 @@
              :provided {:dependencies [[org.clojure/clojure "1.12.0"]]}
              :1.10     {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.11     {:dependencies [[org.clojure/clojure "1.11.4"]]}
-             :1.12     {:dependencies [[org.clojure/clojure "1.12.0"]]}}
+             :1.12     {:dependencies [[org.clojure/clojure "1.12.0"]]}
+             :bench    {:source-paths ["bench"]
+                        :dependencies [[criterium/criterium "0.4.6"]]
+                        :main         clj-zip-meta.bench}}
 
-  :aliases {"test-all" ["with-profile" "+1.10:+1.11:+1.12" "test"]}
+  :aliases {"test-all" ["with-profile" "+1.10:+1.11:+1.12" "test"]
+            "bench"    ["with-profile" "+bench" "run"]}
 
   ;; Deploy credentials are read from the CLOJARS_USERNAME and
   ;; CLOJARS_PASSWORD environment variables — the CI release workflow

--- a/src/main/clj_zip_meta/cli.clj
+++ b/src/main/clj_zip_meta/cli.clj
@@ -1,12 +1,14 @@
 (ns clj-zip-meta.cli
   "Command-line interface to clj-zip-meta.
 
-  Run via `lein run -- COMMAND FILE [args...]`, where COMMAND is one
-  of `list`, `meta`, `summary`, `comment`, `validate`, or `repair`.
-  `lein run` (no args) prints a brief usage banner."
+  Run via `lein run -- COMMAND FILE [args...]` or `clj -M:cli --
+  COMMAND FILE [args...]`. Pass `--json` to any read-only command to
+  emit machine-readable JSON instead of human-readable text."
   (:require [clj-zip-meta.core :as zm]
+            [clojure.java.io :as jio]
             [clojure.pprint :as pp]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [clojure.walk :as walk])
   (:gen-class))
 
 (def ^:private usage
@@ -24,78 +26,171 @@
     "  validate  FILE [--crc]        Check metadata (and optionally CRC-32)"
     "  verify    FILE                Decompress every entry and check CRC-32"
     "  repair    FILE [--strip]      Repair offset drift or rebuild a missing CDR"
+    ""
+    "Global flag:"
+    "  --json    Emit JSON on stdout instead of human-readable text"
     ""]))
 
-(defn- list-entries [f]
-  (printf "%14s %14s %s%n" "compressed" "uncompressed" "name")
-  (printf "%14s %14s %s%n" "----------" "------------" "----")
-  (doseq [e (zm/zip-entries f)]
-    (printf "%14d %14d %s%n"
-            (:compressed-size e)
-            (:uncompressed-size e)
-            (:file-name e)))
-  (flush))
+;; --- minimal JSON emitter -------------------------------------------------
 
-(defn- print-summary [f]
-  (pp/pprint (zm/summarize f)))
+(defn- bytes->hex-str [^bytes ba]
+  (let [sb (StringBuilder.)]
+    (dotimes [i (alength ba)]
+      (.append sb (format "%02x" (bit-and 0xFF (aget ba i)))))
+    (.toString sb)))
 
-(defn- print-meta [f]
-  (zm/print-zip-meta f))
+(declare ->json)
 
-(defn- comment-cmd [f new-comment]
+(defn- escape-string [^String s]
+  (let [sb (StringBuilder.)]
+    (.append sb \")
+    (dotimes [i (.length s)]
+      (let [c (.charAt s i)]
+        (case c
+          \\        (.append sb "\\\\")
+          \"        (.append sb "\\\"")
+          \newline  (.append sb "\\n")
+          \return   (.append sb "\\r")
+          \tab      (.append sb "\\t")
+          \backspace (.append sb "\\b")
+          \formfeed  (.append sb "\\f")
+          (if (< (int c) 0x20)
+            (.append sb (format "\\u%04x" (int c)))
+            (.append sb c)))))
+    (.append sb \")
+    (.toString sb)))
+
+(defn- ->json [v]
+  (cond
+    (nil? v)        "null"
+    (boolean? v)    (if v "true" "false")
+    (number? v)     (str v)
+    (string? v)     (escape-string v)
+    (keyword? v)    (escape-string (subs (str v) 1))
+    (instance? java.time.LocalDateTime v) (escape-string (str v))
+    (map? v)
+    (str "{"
+         (str/join ","
+                   (for [[k val] (sort-by (comp str key) v)]
+                     (str (escape-string (if (keyword? k) (subs (str k) 1) (str k)))
+                          ":" (->json val))))
+         "}")
+    (set? v) (->json (vec (sort-by str v)))
+    (sequential? v) (str "[" (str/join "," (map ->json v)) "]")
+    (and (some? v) (.isArray ^Class (class v))
+         (= "byte" (.getName (.getComponentType ^Class (class v)))))
+    (escape-string (bytes->hex-str v))
+    :else (escape-string (str v))))
+
+;; --- output helpers ------------------------------------------------------
+
+(defn- print-table [headers rows]
+  (let [widths (map (fn [i]
+                      (apply max (count (nth headers i))
+                             (map #(count (str (nth % i))) rows)))
+                    (range (count headers)))
+        fmt    (->> widths (map #(str "%-" % "s")) (str/join "  "))]
+    (println (apply format fmt headers))
+    (println (apply format fmt (map #(apply str (repeat % \-)) widths)))
+    (doseq [r rows]
+      (println (apply format fmt (map str r))))))
+
+(defn- emit [json? human-thunk data]
+  (if json?
+    (do (println (->json data)) (flush))
+    (human-thunk)))
+
+;; --- commands -------------------------------------------------------------
+
+(defn- list-entries [f json?]
+  (let [entries (zm/zip-entries f)]
+    (emit json?
+          (fn []
+            (print-table ["compressed" "uncompressed" "modified" "name"]
+                         (mapv (fn [e]
+                                 [(:compressed-size e)
+                                  (:uncompressed-size e)
+                                  (or (:last-modified e) "")
+                                  (:file-name e)])
+                               entries)))
+          entries)))
+
+(defn- print-summary [f json?]
+  (let [s (zm/summarize f)]
+    (emit json? #(pp/pprint s) s)))
+
+(defn- print-meta [f json?]
+  (let [m (zm/zip-meta f)]
+    (emit json? #(zm/print-zip-meta m) m)))
+
+(defn- comment-cmd [f new-comment json?]
   (if new-comment
     (do (zm/set-zip-comment! f new-comment)
-        (println "comment updated"))
-    (println (zm/zip-comment f))))
+        (emit json? #(println "comment updated")
+              {:status "updated" :comment new-comment}))
+    (let [c (zm/zip-comment f)]
+      (emit json? #(println c) {:comment c}))))
 
-(defn- validate-cmd [f flags]
-  (let [crc?   (contains? (set flags) "--crc")
-        {:keys [valid? issues extra-bytes]}
-        (zm/validate-zip-meta f :verify-crcs crc?)]
-    (println (str "extra-bytes: " extra-bytes))
-    (if valid?
-      (println "OK")
-      (do (println "FAILED")
-          (run! #(println (str "  - " %)) issues)
-          (System/exit 1)))))
+(defn- validate-cmd [f flags json?]
+  (let [crc? (contains? (set flags) "--crc")
+        r    (zm/validate-zip-meta f :verify-crcs crc?)]
+    (emit json?
+          (fn []
+            (println (str "extra-bytes: " (:extra-bytes r)))
+            (if (:valid? r)
+              (println "OK")
+              (do (println "FAILED")
+                  (run! #(println (str "  - " %)) (:issues r)))))
+          r)
+    (when-not (:valid? r) (System/exit 1))))
 
-(defn- verify-cmd [f]
-  (let [{:keys [valid? total counts mismatches errors]}
-        (zm/verify-crcs-summary f)]
-    (println (str "total:    " total))
-    (doseq [[s n] (sort-by key counts)]
-      (println (format "  %-22s %d" (name s) n)))
-    (if valid?
-      (println "OK")
-      (do (when (seq mismatches)
-            (println "mismatches:")
-            (doseq [m mismatches] (println (str "  - " (:file-name m)))))
-          (when (seq errors)
-            (println "errors:")
-            (doseq [m errors]
-              (println (str "  - " (:file-name m) ": " (:error m)))))
-          (System/exit 1)))))
+(defn- verify-cmd [f json?]
+  (let [s (zm/verify-crcs-summary f)]
+    (emit json?
+          (fn []
+            (println (str "total:    " (:total s)))
+            (doseq [[st n] (sort-by key (:counts s))]
+              (println (format "  %-22s %d" (name st) n)))
+            (if (:valid? s)
+              (println "OK")
+              (do (when (seq (:mismatches s))
+                    (println "mismatches:")
+                    (doseq [m (:mismatches s)]
+                      (println (str "  - " (:file-name m)))))
+                  (when (seq (:errors s))
+                    (println "errors:")
+                    (doseq [m (:errors s)]
+                      (println (str "  - " (:file-name m) ": " (:error m))))))))
+          s)
+    (when-not (:valid? s) (System/exit 1))))
 
-(defn- repair-cmd [f flags]
+(defn- repair-cmd [f flags json?]
   (let [strip? (contains? (set flags) "--strip")
         r      (zm/repair-zip f {:strip-preamble strip?})]
-    (println (str "status:  " (name (:status r))))
-    (println (str "actions: " (str/join ", " (map name (:actions r)))))
-    (when (= :failed (:status r))
-      (when (:error r) (println (str "error:   " (:error r))))
-      (run! #(println (str "issue:   " %)) (or (:issues r) []))
-      (System/exit 1))))
+    (emit json?
+          (fn []
+            (println (str "status:  " (name (:status r))))
+            (println (str "actions: " (str/join ", " (map name (:actions r)))))
+            (when (= :failed (:status r))
+              (when (:error r) (println (str "error:   " (:error r))))
+              (run! #(println (str "issue:   " %)) (or (:issues r) []))))
+          (-> r
+              (update :status name)
+              (update :actions #(mapv name %))))
+    (when (= :failed (:status r)) (System/exit 1))))
 
 (defn -main [& args]
-  (let [[cmd file & rest] args]
+  (let [json? (boolean (some #(= "--json" %) args))
+        args  (remove #(= "--json" %) args)
+        [cmd file & rest] args]
     (case cmd
-      "list"     (list-entries file)
-      "meta"     (print-meta file)
-      "summary"  (print-summary file)
-      "comment"  (comment-cmd file (first rest))
-      "validate" (validate-cmd file rest)
-      "verify"   (verify-cmd file)
-      "repair"   (repair-cmd file rest)
+      "list"     (list-entries file json?)
+      "meta"     (print-meta file json?)
+      "summary"  (print-summary file json?)
+      "comment"  (comment-cmd file (first rest) json?)
+      "validate" (validate-cmd file rest json?)
+      "verify"   (verify-cmd file json?)
+      "repair"   (repair-cmd file rest json?)
       (do (println usage)
           (flush)
           (System/exit (if cmd 1 0))))))

--- a/src/main/clj_zip_meta/cli.clj
+++ b/src/main/clj_zip_meta/cli.clj
@@ -11,6 +11,8 @@
             [clojure.walk :as walk])
   (:gen-class))
 
+(def ^:private version "0.3.0")
+
 (def ^:private usage
   (str/join
    "\n"
@@ -27,8 +29,9 @@
     "  verify    FILE                Decompress every entry and check CRC-32"
     "  repair    FILE [--strip]      Repair offset drift or rebuild a missing CDR"
     ""
-    "Global flag:"
-    "  --json    Emit JSON on stdout instead of human-readable text"
+    "Global flags:"
+    "  --json     Emit JSON on stdout instead of human-readable text"
+    "  --version  Print the library version and exit"
     ""]))
 
 ;; --- minimal JSON emitter -------------------------------------------------
@@ -180,6 +183,10 @@
     (when (= :failed (:status r)) (System/exit 1))))
 
 (defn -main [& args]
+  (when (some #(= "--version" %) args)
+    (println (str "clj-zip-meta " version))
+    (flush)
+    (System/exit 0))
   (let [json? (boolean (some #(= "--json" %) args))
         args  (remove #(= "--json" %) args)
         [cmd file & rest] args]

--- a/src/main/clj_zip_meta/cli.clj
+++ b/src/main/clj_zip_meta/cli.clj
@@ -21,7 +21,8 @@
     "  meta      FILE                Pretty-print the full metadata map"
     "  summary   FILE                Print a high-level summary"
     "  comment   FILE [new-comment]  Print or set the archive comment"
-    "  validate  FILE                Check metadata for self-consistency"
+    "  validate  FILE [--crc]        Check metadata (and optionally CRC-32)"
+    "  verify    FILE                Decompress every entry and check CRC-32"
     "  repair    FILE [--strip]      Repair offset drift or rebuild a missing CDR"
     ""]))
 
@@ -47,13 +48,32 @@
         (println "comment updated"))
     (println (zm/zip-comment f))))
 
-(defn- validate-cmd [f]
-  (let [{:keys [valid? issues extra-bytes]} (zm/validate-zip-meta f)]
+(defn- validate-cmd [f flags]
+  (let [crc?   (contains? (set flags) "--crc")
+        {:keys [valid? issues extra-bytes]}
+        (zm/validate-zip-meta f :verify-crcs crc?)]
     (println (str "extra-bytes: " extra-bytes))
     (if valid?
       (println "OK")
       (do (println "FAILED")
           (run! #(println (str "  - " %)) issues)
+          (System/exit 1)))))
+
+(defn- verify-cmd [f]
+  (let [{:keys [valid? total counts mismatches errors]}
+        (zm/verify-crcs-summary f)]
+    (println (str "total:    " total))
+    (doseq [[s n] (sort-by key counts)]
+      (println (format "  %-22s %d" (name s) n)))
+    (if valid?
+      (println "OK")
+      (do (when (seq mismatches)
+            (println "mismatches:")
+            (doseq [m mismatches] (println (str "  - " (:file-name m)))))
+          (when (seq errors)
+            (println "errors:")
+            (doseq [m errors]
+              (println (str "  - " (:file-name m) ": " (:error m)))))
           (System/exit 1)))))
 
 (defn- repair-cmd [f flags]
@@ -73,7 +93,8 @@
       "meta"     (print-meta file)
       "summary"  (print-summary file)
       "comment"  (comment-cmd file (first rest))
-      "validate" (validate-cmd file)
+      "validate" (validate-cmd file rest)
+      "verify"   (verify-cmd file)
       "repair"   (repair-cmd file rest)
       (do (println usage)
           (flush)

--- a/src/main/clj_zip_meta/core.clj
+++ b/src/main/clj_zip_meta/core.clj
@@ -32,6 +32,7 @@
   (:import (java.io File RandomAccessFile)
            (java.nio ByteBuffer ByteOrder MappedByteBuffer)
            (java.nio.channels FileChannel FileChannel$MapMode)
+           (java.nio.charset StandardCharsets)
            (java.util Arrays)))
 
 (declare scan-backwards scan-forwards)
@@ -141,6 +142,137 @@
   [^ByteBuffer bb data spec ^long off]
   (buf/with-byte-order :little-endian
     (buf/write! bb data spec {:offset off})))
+
+;; ----------------------------------------------------------------------------
+;; Hand-rolled fast readers.
+;;
+;; octet is a great library but it pays a heavy per-field cost via
+;; protocol dispatch and dynamic-var lookup; on a 3 770-entry jar a
+;; full zip-meta call was taking ~1.9 s. The readers below operate
+;; directly on a little-endian ByteBuffer and produce records with the
+;; same key/value shape octet would produce, so callers see no
+;; difference. They cut the hot path to a few tens of milliseconds.
+
+(defn- str-utf8 ^String [^ByteBuffer bb ^long pos ^long len]
+  (if (zero? len)
+    ""
+    (let [ba (byte-array (int len))]
+      (.position bb (int pos))
+      (.get bb ba)
+      (String. ba 0 (int len) StandardCharsets/UTF_8))))
+
+(defn- bytes-at ^bytes [^ByteBuffer bb ^long pos ^long len]
+  (let [ba (byte-array (int len))]
+    (when (pos? len)
+      (.position bb (int pos))
+      (.get bb ba))
+    ba))
+
+(defn- read-eocdr! [^ByteBuffer bb ^long pos]
+  (let [sig   (.getInt   bb (int pos))
+        nd    (.getShort bb (int (+ pos 4)))
+        nc    (.getShort bb (int (+ pos 6)))
+        ehere (.getShort bb (int (+ pos 8)))
+        etot  (.getShort bb (int (+ pos 10)))
+        csz   (.getInt   bb (int (+ pos 12)))
+        cof   (.getInt   bb (int (+ pos 16)))
+        clen  (.getShort bb (int (+ pos 20)))
+        cmt   (str-utf8 bb (+ pos 22) (bit-and 0xFFFF clen))]
+    {:end-of-cdr-signature       sig
+     :number-of-this-disk        nd
+     :number-of-cdr-disk         nc
+     :cdr-entries-this-disk      ehere
+     :cdr-entries-total          etot
+     :cdr-size                   csz
+     :cdr-offset-from-start-disk cof
+     :zip-comment-length         clen
+     :zip-comment                cmt}))
+
+(defn- read-cdr! [^ByteBuffer bb ^long pos]
+  (let [sig    (.getInt   bb (int pos))
+        vmade  (.getShort bb (int (+ pos 4)))
+        vneed  (.getShort bb (int (+ pos 6)))
+        gp     (.getShort bb (int (+ pos 8)))
+        meth   (.getShort bb (int (+ pos 10)))
+        time   (.getShort bb (int (+ pos 12)))
+        date   (.getShort bb (int (+ pos 14)))
+        crc    (.getInt   bb (int (+ pos 16)))
+        csize  (.getInt   bb (int (+ pos 20)))
+        usize  (.getInt   bb (int (+ pos 24)))
+        nlen   (.getShort bb (int (+ pos 28)))
+        elen   (.getShort bb (int (+ pos 30)))
+        cmtlen (.getShort bb (int (+ pos 32)))
+        dn     (.getShort bb (int (+ pos 34)))
+        iattr  (.getShort bb (int (+ pos 36)))
+        eattr  (.getInt   bb (int (+ pos 38)))
+        roff   (.getInt   bb (int (+ pos 42)))
+        nlu    (bit-and 0xFFFF nlen)
+        elu    (bit-and 0xFFFF elen)
+        clu    (bit-and 0xFFFF cmtlen)
+        nm     (str-utf8 bb (+ pos 46)          nlu)
+        ex     (bytes-at bb (+ pos 46 nlu)      elu)
+        cmt    (str-utf8 bb (+ pos 46 nlu elu)  clu)]
+    {:cdr-header-signature         sig
+     :version-made-by              vmade
+     :version-needed-to-extract    vneed
+     :general-purpose              gp
+     :compression-method           meth
+     :last-mod-file-time           time
+     :last-mod-file-date           date
+     :crc-32                       crc
+     :compressed-size              csize
+     :uncompressed-size            usize
+     :file-name-length             nlen
+     :extra-field-length           elen
+     :file-comment-length          cmtlen
+     :disk-number-start            dn
+     :internal-file-attributes     iattr
+     :external-file-attributes     eattr
+     :relative-offset-local-header roff
+     :file-name                    nm
+     :extra-field                  ex
+     :file-comment                 cmt}))
+
+(defn- cdr-size* ^long [cdr]
+  (+ 46
+     (bit-and 0xFFFF (long (:file-name-length    cdr)))
+     (bit-and 0xFFFF (long (:extra-field-length  cdr)))
+     (bit-and 0xFFFF (long (:file-comment-length cdr)))))
+
+(defn- read-lfh! [^ByteBuffer bb ^long pos]
+  (let [sig   (.getInt   bb (int pos))
+        vneed (.getShort bb (int (+ pos 4)))
+        gp    (.getShort bb (int (+ pos 6)))
+        meth  (.getShort bb (int (+ pos 8)))
+        time  (.getShort bb (int (+ pos 10)))
+        date  (.getShort bb (int (+ pos 12)))
+        crc   (.getInt   bb (int (+ pos 14)))
+        csize (.getInt   bb (int (+ pos 18)))
+        usize (.getInt   bb (int (+ pos 22)))
+        nlen  (.getShort bb (int (+ pos 26)))
+        elen  (.getShort bb (int (+ pos 28)))
+        nlu   (bit-and 0xFFFF nlen)
+        elu   (bit-and 0xFFFF elen)
+        nm    (str-utf8 bb (+ pos 30)     nlu)
+        ex    (bytes-at bb (+ pos 30 nlu) elu)]
+    {:local-header-signature    sig
+     :version-needed-to-extract vneed
+     :general-purpose           gp
+     :compression-method        meth
+     :last-mod-file-time        time
+     :last-mod-file-date        date
+     :crc-32                    crc
+     :compressed-size           csize
+     :uncompressed-size         usize
+     :file-name-length          nlen
+     :extra-field-length        elen
+     :file-name                 nm
+     :extra-field               ex}))
+
+(defn- lfh-size* ^long [lfh]
+  (+ 30
+     (bit-and 0xFFFF (long (:file-name-length lfh)))
+     (bit-and 0xFFFF (long (:extra-field-length lfh)))))
 
 ;; ============================================================================
 ;; Public low-level API
@@ -284,8 +416,8 @@
          n   entries]
     (if (zero? n)
       (persistent! acc)
-      (let [record (read-spec-bb bb rec-cdr-header off)
-            sz     (long (ospec/size* rec-cdr-header record))]
+      (let [record (read-cdr! bb off)
+            sz     (cdr-size* record)]
         (recur (conj! acc {:offset off :record record})
                (+ off sz)
                (dec n))))))
@@ -299,7 +431,7 @@
   (mapv
     (fn [cdr]
       (let [off    (+ (long (:relative-offset-local-header cdr)) extra-bytes)
-            record (read-spec-bb bb rec-local-file-header off)]
+            record (read-lfh! bb off)]
         {:offset off :record record}))
     cdr-records))
 
@@ -343,7 +475,7 @@
                              (throw (ex-info "End-of-central-directory record not found"
                                              {:file (str f) :length len})))
           bb             (map-region r "r" eocdr-off (- len eocdr-off))
-          eocdr-rec      (read-spec-bb bb rec-end-of-cdr 0)
+          eocdr-rec      (read-eocdr! bb 0)
           cdr-recorded   (+ (long (:cdr-offset-from-start-disk eocdr-rec))
                             (long (:cdr-size eocdr-rec)))
           extra-bytes    (- eocdr-off cdr-recorded)
@@ -392,7 +524,7 @@
                                               {:file (str f) :length len})))
            ^ByteBuffer
            file-bb        (map-region r "r" 0 len)
-           eocdr-rec      (read-spec-bb file-bb rec-end-of-cdr eocdr-off)
+           eocdr-rec      (read-eocdr! file-bb eocdr-off)
            cdr-recorded   (+ (long (:cdr-offset-from-start-disk eocdr-rec))
                              (long (:cdr-size eocdr-rec)))
            extra-bytes    (- eocdr-off cdr-recorded)
@@ -615,9 +747,9 @@
                (persistent! acc)
 
                (= lfh-sig-int sig-int)
-               (let [lfh      (read-spec-bb bb rec-local-file-header pos)
+               (let [lfh      (read-lfh! bb pos)
                      gp       (long (:general-purpose lfh))
-                     hdr-size (long (ospec/size* rec-local-file-header lfh))]
+                     hdr-size (lfh-size* lfh)]
                  (if (pos? (bit-and gp 0x8))
                    (let [data-start (+ pos hdr-size)
                          dd         (locate-data-descriptor bb data-start len)]

--- a/src/main/clj_zip_meta/core.clj
+++ b/src/main/clj_zip_meta/core.clj
@@ -33,6 +33,7 @@
            (java.nio ByteBuffer ByteOrder MappedByteBuffer)
            (java.nio.channels FileChannel FileChannel$MapMode)
            (java.nio.charset StandardCharsets)
+           (java.time LocalDateTime)
            (java.util Arrays)))
 
 (declare scan-backwards scan-forwards)
@@ -274,6 +275,166 @@
      (bit-and 0xFFFF (long (:file-name-length lfh)))
      (bit-and 0xFFFF (long (:extra-field-length lfh)))))
 
+;; ----------------------------------------------------------------------------
+;; Decoded convenience fields
+;;
+;; The raw record fields preserve the on-disk bit pattern verbatim
+;; (so writes can round-trip cleanly). These helpers layer
+;; higher-level interpretations on top:
+;;
+;;   :last-modified      java.time.LocalDateTime decoded from
+;;                       :last-mod-file-time + :last-mod-file-date
+;;   :dos-attributes     set of keywords decoded from the low byte of
+;;                       :external-file-attributes (CDR) — :read-only
+;;                       :hidden :system :volume :directory :archive
+;;   :unix-mode          Unix file mode from the high 16 bits of
+;;                       :external-file-attributes when version-made-by
+;;                       reports Unix (host code 3); nil otherwise.
+;;   :directory?         convenience boolean (file name ends with "/" or
+;;                       DOS directory bit is set)
+;;   :encrypted?         general-purpose bit 0
+;;   :utf8-name?         general-purpose bit 11
+;;   :extra-fields       parsed list of TLVs from :extra-field
+;;                       (each {:tag T :data bytes [+ decoded keys]}).
+
+(defn- ^LocalDateTime dos->ldt [^long dos-date ^long dos-time]
+  (let [year   (+ 1980 (bit-and 0x7F (unsigned-bit-shift-right dos-date 9)))
+        month  (bit-and 0x0F (unsigned-bit-shift-right dos-date 5))
+        day    (bit-and 0x1F dos-date)
+        hour   (bit-and 0x1F (unsigned-bit-shift-right dos-time 11))
+        minute (bit-and 0x3F (unsigned-bit-shift-right dos-time 5))
+        second (* 2 (bit-and 0x1F dos-time))]
+    (when (and (<= 1 month 12) (<= 1 day 31)
+               (<= 0 hour 23) (<= 0 minute 59) (<= 0 second 59))
+      (try (LocalDateTime/of (int year) (int month) (int day)
+                             (int hour) (int minute) (int second))
+           (catch Exception _ nil)))))
+
+(def ^:private dos-attr-bits
+  [[0x01 :read-only]
+   [0x02 :hidden]
+   [0x04 :system]
+   [0x08 :volume]
+   [0x10 :directory]
+   [0x20 :archive]])
+
+(defn- dos-attrs [^long external-file-attributes]
+  (let [low (bit-and 0xFF external-file-attributes)]
+    (persistent!
+      (reduce
+        (fn [acc [bit kw]]
+          (if (pos? (bit-and bit low)) (conj! acc kw) acc))
+        (transient #{})
+        dos-attr-bits))))
+
+(defn- unix-mode-from
+  "Decode the Unix mode from `:external-file-attributes` when
+  version-made-by's host byte is Unix (3). The mode lives in the
+  high 16 bits (bits 16..31 after a shift)."
+  [^long version-made-by ^long external-file-attributes]
+  (when (= 3 (bit-and 0xFF (unsigned-bit-shift-right version-made-by 8)))
+    (bit-and 0xFFFF (unsigned-bit-shift-right external-file-attributes 16))))
+
+(def ^:private extra-tags
+  {0x0001 :zip64
+   0x000A :ntfs
+   0x000D :pkware-unix
+   0x5455 :extended-timestamp
+   0x5855 :infozip-unix-old
+   0x7855 :infozip-unix-new
+   0x6375 :infozip-utf8-comment
+   0x7075 :infozip-utf8-path
+   0x9901 :aes})
+
+(defn- read-bytes-from
+  [^bytes ba ^long off ^long len]
+  (let [out (byte-array (int len))]
+    (System/arraycopy ba (int off) out 0 (int len))
+    out))
+
+(defn- decode-extended-timestamp
+  "Bit 0: mtime, bit 1: atime, bit 2: ctime; each present time is a
+  signed 32-bit Unix timestamp following the flag byte."
+  [^bytes data]
+  (try
+    (when (pos? (alength data))
+      (let [bb    (-> (ByteBuffer/wrap data) (.order ByteOrder/LITTLE_ENDIAN))
+            flags (bit-and 0xFF (long (.get bb 0)))
+            out   (transient {:flags flags})]
+        (loop [pos 1
+               kws [[0x01 :mtime] [0x02 :atime] [0x04 :ctime]]]
+          (if (or (empty? kws) (> (+ pos 4) (alength data)))
+            (persistent! out)
+            (let [[bit kw] (first kws)]
+              (if (pos? (bit-and bit flags))
+                (do (assoc! out kw (.getInt bb (int pos)))
+                    (recur (+ pos 4) (rest kws)))
+                (recur pos (rest kws))))))))
+    (catch Exception _ nil)))
+
+(defn- decode-extra-field [tag ^bytes data]
+  (case tag
+    :extended-timestamp (decode-extended-timestamp data)
+    nil))
+
+(defn- parse-extra-fields
+  "Parse the byte array `ba` as a sequence of zip extra-field TLV
+  records. Returns a vector of `{:tag T :tag-name K :size N :data bytes}`
+  maps, where `:tag-name` is a known keyword (or nil) and `:decoded`
+  appears when the tag has a decoder."
+  [^bytes ba]
+  (let [len (alength ba)]
+    (loop [pos 0
+           acc (transient [])]
+      (if (> (+ pos 4) len)
+        (persistent! acc)
+        (let [bb     (-> (ByteBuffer/wrap ba) (.order ByteOrder/LITTLE_ENDIAN))
+              tag-i  (bit-and 0xFFFF (long (.getShort bb (int pos))))
+              size   (bit-and 0xFFFF (long (.getShort bb (int (+ pos 2)))))
+              end    (+ pos 4 size)]
+          (if (> end len)
+            (persistent! acc)
+            (let [data    (read-bytes-from ba (+ pos 4) size)
+                  tag-kw  (get extra-tags tag-i)
+                  base    {:tag tag-i :tag-name tag-kw :size size :data data}
+                  decoded (when tag-kw (decode-extra-field tag-kw data))]
+              (recur end
+                     (conj! acc (cond-> base
+                                  decoded (assoc :decoded decoded)))))))))))
+
+(defn- decorate-cdr
+  "Add decoded convenience keys to a raw CDR record."
+  [cdr]
+  (let [gp     (long (:general-purpose cdr))
+        eattr  (long (:external-file-attributes cdr))
+        vmade  (long (:version-made-by cdr))
+        name   (:file-name cdr)
+        dattrs (dos-attrs eattr)]
+    (assoc cdr
+      :last-modified    (dos->ldt (long (:last-mod-file-date cdr))
+                                  (long (:last-mod-file-time cdr)))
+      :dos-attributes   dattrs
+      :unix-mode        (unix-mode-from vmade eattr)
+      :directory?       (or (contains? dattrs :directory)
+                            (and (string? name) (str/ends-with? name "/")))
+      :encrypted?       (pos? (bit-and gp 0x0001))
+      :utf8-name?       (pos? (bit-and gp 0x0800))
+      :extra-fields     (parse-extra-fields (:extra-field cdr)))))
+
+(defn- decorate-lfh
+  "Add decoded convenience keys to a raw LFH record (no
+  :external-file-attributes here)."
+  [lfh]
+  (let [gp   (long (:general-purpose lfh))
+        name (:file-name lfh)]
+    (assoc lfh
+      :last-modified  (dos->ldt (long (:last-mod-file-date lfh))
+                                (long (:last-mod-file-time lfh)))
+      :directory?     (and (string? name) (str/ends-with? name "/"))
+      :encrypted?     (pos? (bit-and gp 0x0001))
+      :utf8-name?     (pos? (bit-and gp 0x0800))
+      :extra-fields   (parse-extra-fields (:extra-field lfh)))))
+
 ;; ============================================================================
 ;; Public low-level API
 
@@ -410,14 +571,15 @@
 (defn- read-cdr-records*
   "Read `entries` consecutive CDR records from `bb` starting at byte
   position `start-off`. Returns a vector of `{:offset N :record M}`."
-  [^ByteBuffer bb ^long start-off ^long entries]
+  [^ByteBuffer bb ^long start-off ^long entries decode?]
   (loop [acc (transient [])
          off start-off
          n   entries]
     (if (zero? n)
       (persistent! acc)
-      (let [record (read-cdr! bb off)
-            sz     (cdr-size* record)]
+      (let [raw    (read-cdr! bb off)
+            sz     (cdr-size* raw)
+            record (if decode? (decorate-cdr raw) raw)]
         (recur (conj! acc {:offset off :record record})
                (+ off sz)
                (dec n))))))
@@ -427,32 +589,38 @@
   buffer that covers the start of the file at least through the
   beginning of the central directory. `extra-bytes` is added to each
   recorded `:relative-offset-local-header`."
-  [^ByteBuffer bb cdr-records ^long extra-bytes]
+  [^ByteBuffer bb cdr-records ^long extra-bytes decode?]
   (mapv
     (fn [cdr]
-      (let [off    (+ (long (:relative-offset-local-header cdr)) extra-bytes)
-            record (read-lfh! bb off)]
-        {:offset off :record record}))
+      (let [off (+ (long (:relative-offset-local-header cdr)) extra-bytes)
+            raw (read-lfh! bb off)]
+        {:offset off
+         :record (if decode? (decorate-lfh raw) raw)}))
     cdr-records))
 
 (defn get-cdr-records
   "Read `entries` central directory records from file `f` starting at
-  byte offset `off`. Returns a vector of `{:offset N :record M}`."
+  byte offset `off`. Returns a vector of `{:offset N :record M}`.
+  Records include the decoded convenience keys
+  (`:last-modified`, `:dos-attributes`, `:unix-mode`, `:directory?`,
+  `:encrypted?`, `:utf8-name?`, `:extra-fields`)."
   [f off entries]
   {:pre [(valid-offset? off)]}
   (with-raf [r f "r"]
     (let [bb (map-region r "r" 0 (.length r))]
-      (read-cdr-records* bb (long off) (long entries)))))
+      (read-cdr-records* bb (long off) (long entries) true))))
 
 (defn get-local-records
   "Read the local file headers referenced by `cdr-records` from file
   `f`. `cdr-offset` is the central-directory start offset (used as a
   buffer-mapping upper bound). `extra-bytes` is added to each
-  `:relative-offset-local-header` value."
+  `:relative-offset-local-header` value. Records include the decoded
+  convenience keys (`:last-modified`, `:directory?`, `:encrypted?`,
+  `:utf8-name?`, `:extra-fields`)."
   [f cdr-records cdr-offset extra-bytes]
   (with-raf [r f "r"]
     (let [bb (map-region r "r" 0 (long cdr-offset))]
-      (read-local-records* bb cdr-records (long extra-bytes)))))
+      (read-local-records* bb cdr-records (long extra-bytes) true))))
 
 (defn read-end-of-cdr-record
   "Find and read the end-of-central-directory record from `f`.
@@ -509,14 +677,21 @@
   when only the central directory is needed.
 
   Each `:record` map mirrors the corresponding zip-specification
-  record (see `clj-zip-meta.spec` and APPNOTE.TXT §4.3). Throws
-  `ex-info` if the archive is malformed.
+  record (see `clj-zip-meta.spec` and APPNOTE.TXT §4.3) and is
+  augmented with decoded convenience keys: `:last-modified`
+  (LocalDateTime), `:directory?`, `:encrypted?`, `:utf8-name?`,
+  `:extra-fields` (parsed TLV vector), and on CDR entries
+  `:dos-attributes` (set) and `:unix-mode` (octal). Pass
+  `{:decode false}` to skip decoration and get the raw fields only.
+
+  Throws `ex-info` if the archive is malformed.
 
   Performance note: this function memory-maps the file once and reads
   every record from a single mapping; the channel is released as the
   function returns."
   ([f] (zip-meta f {}))
-  ([f {:keys [include-locals] :or {include-locals true}}]
+  ([f {:keys [include-locals decode]
+       :or   {include-locals true decode true}}]
    (with-raf [r f "r"]
      (let [len            (.length r)
            eocdr-off      (or (find-end-of-cdr-offset r)
@@ -542,13 +717,14 @@
                                                  :expected-cdr-off cdr-off-actual
                                                  :extra-bytes      extra-bytes}))))
            entries        (long (:cdr-entries-total eocdr-rec))
-           cdrs           (read-cdr-records* file-bb cdr-off-actual entries)
+           cdrs           (read-cdr-records* file-bb cdr-off-actual entries (boolean decode))
            base           {:extra-bytes       extra-bytes
                            :end-of-cdr-record {:offset eocdr-off :record eocdr-rec}
                            :cdr-records       cdrs}]
        (if include-locals
          (assoc base :local-records
-                (read-local-records* file-bb (mapv :record cdrs) extra-bytes))
+                (read-local-records* file-bb (mapv :record cdrs)
+                                     extra-bytes (boolean decode)))
          base)))))
 
 ;; ============================================================================

--- a/src/main/clj_zip_meta/core.clj
+++ b/src/main/clj_zip_meta/core.clj
@@ -277,6 +277,64 @@
      (bit-and 0xFFFF (long (:extra-field-length lfh)))))
 
 ;; ----------------------------------------------------------------------------
+;; Hand-rolled writers (mirroring the readers above).
+;;
+;; Octet handles writes correctly but at the same per-field protocol-
+;; dispatch cost as reads. These writers operate directly on a
+;; little-endian ByteBuffer. Each returns the total number of bytes
+;; written. The public octet-based write-spec-to-* functions are kept
+;; for backwards compatibility.
+
+(defn- write-eocdr! ^long [^ByteBuffer bb ^long pos eocdr]
+  (let [cmt  (str (or (:zip-comment eocdr) ""))
+        cbs  (.getBytes cmt "UTF-8")
+        clen (alength cbs)]
+    (.putInt   bb (int pos)        (unchecked-int   (long (:end-of-cdr-signature       eocdr))))
+    (.putShort bb (int (+ pos 4))  (unchecked-short (long (:number-of-this-disk        eocdr))))
+    (.putShort bb (int (+ pos 6))  (unchecked-short (long (:number-of-cdr-disk         eocdr))))
+    (.putShort bb (int (+ pos 8))  (unchecked-short (long (:cdr-entries-this-disk      eocdr))))
+    (.putShort bb (int (+ pos 10)) (unchecked-short (long (:cdr-entries-total          eocdr))))
+    (.putInt   bb (int (+ pos 12)) (unchecked-int   (long (:cdr-size                   eocdr))))
+    (.putInt   bb (int (+ pos 16)) (unchecked-int   (long (:cdr-offset-from-start-disk eocdr))))
+    (.putShort bb (int (+ pos 20)) (unchecked-short (long clen)))
+    (when (pos? clen)
+      (.position bb (int (+ pos 22)))
+      (.put bb cbs))
+    (+ 22 clen)))
+
+(defn- write-cdr! ^long [^ByteBuffer bb ^long pos cdr]
+  (let [nm   (str (or (:file-name    cdr) ""))
+        cmt  (str (or (:file-comment cdr) ""))
+        ex   (or  (:extra-field cdr) (byte-array 0))
+        nbs  (.getBytes nm "UTF-8")
+        cbs  (.getBytes cmt "UTF-8")
+        nlen (alength nbs)
+        elen (alength ^bytes ex)
+        clen (alength cbs)]
+    (.putInt   bb (int pos)        (unchecked-int   (long (:cdr-header-signature         cdr))))
+    (.putShort bb (int (+ pos 4))  (unchecked-short (long (:version-made-by              cdr))))
+    (.putShort bb (int (+ pos 6))  (unchecked-short (long (:version-needed-to-extract    cdr))))
+    (.putShort bb (int (+ pos 8))  (unchecked-short (long (:general-purpose              cdr))))
+    (.putShort bb (int (+ pos 10)) (unchecked-short (long (:compression-method           cdr))))
+    (.putShort bb (int (+ pos 12)) (unchecked-short (long (:last-mod-file-time           cdr))))
+    (.putShort bb (int (+ pos 14)) (unchecked-short (long (:last-mod-file-date           cdr))))
+    (.putInt   bb (int (+ pos 16)) (unchecked-int   (long (:crc-32                       cdr))))
+    (.putInt   bb (int (+ pos 20)) (unchecked-int   (long (:compressed-size              cdr))))
+    (.putInt   bb (int (+ pos 24)) (unchecked-int   (long (:uncompressed-size            cdr))))
+    (.putShort bb (int (+ pos 28)) (unchecked-short (long nlen)))
+    (.putShort bb (int (+ pos 30)) (unchecked-short (long elen)))
+    (.putShort bb (int (+ pos 32)) (unchecked-short (long clen)))
+    (.putShort bb (int (+ pos 34)) (unchecked-short (long (:disk-number-start            cdr))))
+    (.putShort bb (int (+ pos 36)) (unchecked-short (long (:internal-file-attributes     cdr))))
+    (.putInt   bb (int (+ pos 38)) (unchecked-int   (long (:external-file-attributes     cdr))))
+    (.putInt   bb (int (+ pos 42)) (unchecked-int   (long (:relative-offset-local-header cdr))))
+    (.position bb (int (+ pos 46)))
+    (when (pos? nlen) (.put bb nbs))
+    (when (pos? elen) (.put bb ^bytes ex))
+    (when (pos? clen) (.put bb cbs))
+    (+ 46 nlen elen clen)))
+
+;; ----------------------------------------------------------------------------
 ;; Decoded convenience fields
 ;;
 ;; The raw record fields preserve the on-disk bit pattern verbatim
@@ -749,13 +807,11 @@
         (let [len (.length r)
               bb  (map-region r "rw" 0 len)]
           (doseq [{offset :offset cdr :record} (:cdr-records meta)]
-            (write-spec-bb! bb
-                            (update cdr :relative-offset-local-header + extra-bytes)
-                            rec-cdr-header offset))
+            (write-cdr! bb offset
+                        (update cdr :relative-offset-local-header + extra-bytes)))
           (let [{eo-off :offset eo :record} (:end-of-cdr-record meta)]
-            (write-spec-bb! bb
-                            (update eo :cdr-offset-from-start-disk + extra-bytes)
-                            rec-end-of-cdr eo-off))
+            (write-eocdr! bb eo-off
+                          (update eo :cdr-offset-from-start-disk + extra-bytes)))
           (.force ^MappedByteBuffer bb))))
     f))
 
@@ -1057,9 +1113,9 @@
                             base)))
                       locals)
          cdr-start (long (:end-offset (last locals)))
-         cdr-size  (reduce + 0 (map #(long (ospec/size* rec-cdr-header %)) cdrs))
+         cdr-size  (reduce + 0 (map cdr-size* cdrs))
          eocdr     (mk-eocdr cdrs (- cdr-start extra) cdr-size zip-comment)
-         eocdr-size (long (ospec/size* rec-end-of-cdr eocdr))
+         eocdr-size (+ 22 (alength (.getBytes ^String zip-comment "UTF-8")))
          total     (+ cdr-start cdr-size eocdr-size)]
      (with-raf [r f "rw"]
        (.setLength r total)
@@ -1067,10 +1123,10 @@
          (loop [pos cdr-start
                 rs  cdrs]
            (when-let [rec (first rs)]
-             (write-spec-bb! bb rec rec-cdr-header pos)
-             (recur (+ pos (long (ospec/size* rec-cdr-header rec)))
+             (write-cdr! bb pos rec)
+             (recur (+ pos (cdr-size* rec))
                     (rest rs))))
-         (write-spec-bb! bb eocdr rec-end-of-cdr (+ cdr-start cdr-size))
+         (write-eocdr! bb (+ cdr-start cdr-size) eocdr)
          (.force ^MappedByteBuffer bb)))
      f)))
 
@@ -1342,16 +1398,16 @@
     (when (> (alength cbytes) 0xFFFF)
       (throw (ex-info "zip comment exceeds the 65 535-byte maximum"
                       {:length (alength cbytes)})))
-    (let [m       (zip-meta f {:include-locals false})
+    (let [m       (zip-meta f {:include-locals false :decode false})
           {eo-off :offset eo :record} (:end-of-cdr-record m)
           new-eo  (assoc eo :zip-comment comment
                            :zip-comment-length (alength cbytes))
-          new-eo-size (long (ospec/size* rec-end-of-cdr new-eo))
+          new-eo-size (+ 22 (alength cbytes))
           new-len     (+ (long eo-off) new-eo-size)]
       (with-raf [r f "rw"]
         (.setLength r new-len)
         (let [^ByteBuffer bb (map-region r "rw" 0 new-len)]
-          (write-spec-bb! bb new-eo rec-end-of-cdr eo-off)
+          (write-eocdr! bb eo-off new-eo)
           (.force ^MappedByteBuffer bb))))
     f))
 

--- a/src/main/clj_zip_meta/core.clj
+++ b/src/main/clj_zip_meta/core.clj
@@ -34,7 +34,8 @@
            (java.nio.channels FileChannel FileChannel$MapMode)
            (java.nio.charset StandardCharsets)
            (java.time LocalDateTime)
-           (java.util Arrays)))
+           (java.util Arrays)
+           (java.util.zip CRC32 Inflater)))
 
 (declare scan-backwards scan-forwards)
 
@@ -768,13 +769,17 @@
 
   Options:
 
-    `:repair` — when truthy, rewrites prepended-byte offset drift in
-                place before re-running the validation. Defaults to
-                false.
-    `:print`  — when truthy, prints each issue to `*out*`. Defaults
-                to false. Provided for compatibility with the prior
-                side-effecting behavior."
-  [f & {:keys [repair print]}]
+    `:repair`     — when truthy, rewrites prepended-byte offset
+                    drift in place before re-running the validation.
+                    Defaults to false.
+    `:verify-crcs` — when truthy, also runs `verify-crcs` and rolls
+                    any CRC mismatches / inflate errors into the
+                    `:issues` vector. Defaults to false because it
+                    has to read every entry's compressed data.
+    `:print`      — when truthy, prints each issue to `*out*`.
+                    Defaults to false. Provided for compatibility
+                    with the prior side-effecting behavior."
+  [f & {:keys [repair print verify-crcs]}]
   (when repair
     (repair-zip-with-preamble-bytes f))
   (let [meta   (zip-meta f)
@@ -782,6 +787,10 @@
         locals (:local-records meta)
         cdrs   (:cdr-records meta)
         extra  (long (:extra-bytes meta))
+        crc-fail (when verify-crcs
+                   (->> (verify-crcs f)
+                        (filter #(contains? #{:mismatch :error} (:status %)))
+                        seq))
         issues (cond-> []
                  (pos? extra)
                  (conj (str extra " extra bytes at beginning or within zipfile"))
@@ -800,7 +809,12 @@
                          (not (valid-signature? f offset 4
                                                 (sig-bytes rec-local-file-header-sig))))
                        locals)
-                 (conj "invalid local record signatures found"))]
+                 (conj "invalid local record signatures found")
+
+                 crc-fail
+                 (into (map (fn [r]
+                              (str "CRC " (name (:status r)) " for " (:file-name r)))
+                            crc-fail)))]
     (when print (run! println issues))
     {:valid?      (empty? issues)
      :issues      issues
@@ -1172,6 +1186,11 @@
     `:crc-32`              — CRC-32 of the uncompressed data
     `:compression-method`  — 0 = stored, 8 = deflate, etc.
     `:offset`              — file offset of the CDR record
+    `:directory?`          — true if the entry is a directory
+    `:encrypted?`          — true if general-purpose bit 0 is set
+    `:last-modified`       — `java.time.LocalDateTime` of the entry
+    `:unix-mode`           — Unix file mode (octal) or nil
+    `:dos-attributes`      — set of DOS-attribute keywords
 
   Reads only the central directory — much faster than `zip-meta` for
   archives with many entries when local file headers are not needed."
@@ -1184,7 +1203,12 @@
        :uncompressed-size  (:uncompressed-size cdr)
        :crc-32             (:crc-32 cdr)
        :compression-method (:compression-method cdr)
-       :offset             offset})
+       :offset             offset
+       :directory?         (:directory? cdr)
+       :encrypted?         (:encrypted? cdr)
+       :last-modified      (:last-modified cdr)
+       :unix-mode          (:unix-mode cdr)
+       :dos-attributes     (:dos-attributes cdr)})
     (:cdr-records (zip-meta f {:include-locals false}))))
 
 (defn find-entry
@@ -1192,6 +1216,113 @@
   compact summary map (see `zip-entries`) or `nil` if not found."
   [f file-name]
   (some #(when (= (:file-name %) file-name) %) (zip-entries f)))
+
+;; ----------------------------------------------------------------------------
+;; CRC verification
+
+(defn- compute-crc-for-entry
+  "Verify one entry's data against its recorded CRC-32. Returns a
+  map with :file-name, :status (`:ok` / `:mismatch` / `:empty` /
+  `:unsupported-method` / `:error`), :recorded-crc, optional
+  :computed-crc, optional :error / :method."
+  [^ByteBuffer file-bb cdr ^long extra-bytes]
+  (let [name      (:file-name cdr)
+        recorded  (long (:crc-32 cdr))
+        recorded* (bit-and 0xFFFFFFFF recorded)
+        meth      (long (:compression-method cdr))
+        usize     (long (:uncompressed-size cdr))
+        csize     (long (:compressed-size cdr))
+        lfh-off   (+ (long (:relative-offset-local-header cdr)) extra-bytes)
+        nlen      (bit-and 0xFFFF (long (.getShort file-bb (int (+ lfh-off 26)))))
+        elen      (bit-and 0xFFFF (long (.getShort file-bb (int (+ lfh-off 28)))))
+        data-off  (+ lfh-off 30 nlen elen)
+        base      {:file-name name :recorded-crc recorded}]
+    (cond
+      (zero? usize)
+      (assoc base :status :empty)
+
+      (= 0 meth)
+      (try
+        (let [data (byte-array (int csize))]
+          (.position file-bb (int data-off))
+          (.get file-bb data)
+          (let [c        (doto (CRC32.) (.update data))
+                computed (.getValue c)]
+            (assoc base
+              :status       (if (= recorded* computed) :ok :mismatch)
+              :computed-crc computed)))
+        (catch Exception e
+          (assoc base :status :error :error (.getMessage e))))
+
+      (= 8 meth)
+      (let [compressed (byte-array (int csize))
+            inflater   (Inflater. true)]
+        (try
+          (.position file-bb (int data-off))
+          (.get file-bb compressed)
+          (.setInput inflater compressed)
+          (let [out    (byte-array (int usize))
+                ilen   (.inflate inflater out 0 (int usize))
+                c      (doto (CRC32.) (.update out 0 ilen))
+                computed (.getValue c)]
+            (assoc base
+              :status       (if (= recorded* computed) :ok :mismatch)
+              :computed-crc computed))
+          (catch Exception e
+            (assoc base :status :error :error (.getMessage e)))
+          (finally (.end inflater))))
+
+      :else
+      (assoc base :status :unsupported-method :method meth))))
+
+(defn verify-crcs
+  "Read every entry's compressed data from `f`, decompress it, and
+  compare the resulting CRC-32 against the value recorded in the
+  central directory. Returns a vector of maps, one per entry:
+
+      {:file-name    the entry name
+       :status       :ok | :mismatch | :empty | :unsupported-method | :error
+       :recorded-crc the recorded CRC-32 (signed long, as octet returns)
+       :computed-crc the computed CRC-32 (unsigned long; only present
+                      when actually computed)
+       :method       the compression method (only when :unsupported-method)
+       :error        the exception message (only when :error)}
+
+  Supports STORED (0) and DEFLATE (8) — the methods used by every
+  jar and the vast majority of zips. Other methods (BZIP2, LZMA,
+  etc.) yield `:unsupported-method` so the caller can decide whether
+  to treat that as a failure.
+
+  This is the strongest integrity check the library performs: it
+  verifies the data itself, not just the metadata."
+  [f]
+  (with-raf [r f "r"]
+    (let [len            (.length r)
+          ^ByteBuffer bb (map-region r "r" 0 len)
+          m              (zip-meta r {:decode false :include-locals false})
+          extra          (long (:extra-bytes m))]
+      (mapv #(compute-crc-for-entry bb (:record %) extra) (:cdr-records m)))))
+
+(defn verify-crcs-summary
+  "Run `verify-crcs` and return a map summarising the per-status
+  counts plus the entries (if any) whose CRC did not match:
+
+      {:total       N
+       :counts      {:ok N :mismatch N :empty N
+                     :unsupported-method N :error N}
+       :mismatches  [{...verify entry...} ...]
+       :errors      [{...} ...]
+       :valid?      true iff every non-skipped entry verified}"
+  [f]
+  (let [results (verify-crcs f)
+        counts  (frequencies (map :status results))
+        mis     (filterv #(= :mismatch (:status %)) results)
+        errs    (filterv #(= :error    (:status %)) results)]
+    {:total      (count results)
+     :counts     counts
+     :mismatches mis
+     :errors     errs
+     :valid?     (and (empty? mis) (empty? errs))}))
 
 (defn zip-comment
   "Return the archive-level comment from `f` (an empty string if

--- a/src/test/clj_zip_meta/core_test.clj
+++ b/src/test/clj_zip_meta/core_test.clj
@@ -171,12 +171,13 @@
 (deftest zip-meta-can-skip-local-records
   (let [full (zm/zip-meta good-file)
         cdr  (zm/zip-meta good-file {:include-locals false})
-        ;; CDR records are read separately on each call so the byte
-        ;; arrays in :extra-field are distinct objects even with
-        ;; identical content. Compare on the comparable primitive
-        ;; fields instead.
+        ;; Byte arrays inside the records (`:extra-field` and
+        ;; `:extra-fields[*].data`) are distinct objects on each
+        ;; read even when their contents match. Drop them before
+        ;; comparing.
         scrub (fn [recs]
-                (mapv #(update % :record dissoc :extra-field) recs))]
+                (mapv #(update % :record dissoc :extra-field :extra-fields)
+                      recs))]
     (is (contains? full :local-records))
     (is (not (contains? cdr :local-records)))
     (is (= (scrub (:cdr-records full)) (scrub (:cdr-records cdr))))
@@ -189,6 +190,41 @@
     (zm/set-zip-comment! tmp "hello, comment!")
     (is (= "hello, comment!" (zm/zip-comment tmp)))
     (is (true? (:valid? (zm/validate-zip-meta tmp))))))
+
+(deftest cdr-records-have-decoded-convenience-keys
+  (let [recs (->> (zm/zip-meta good-file) :cdr-records (mapv :record))
+        dir  (first (filter :directory? recs))
+        file (first (remove :directory? recs))]
+    (testing "every record has the decode-augmented keys"
+      (doseq [r recs]
+        (is (some? (:last-modified r)))
+        (is (set? (:dos-attributes r)))
+        (is (contains? r :unix-mode))
+        (is (contains? r :directory?))
+        (is (contains? r :encrypted?))
+        (is (contains? r :utf8-name?))
+        (is (vector? (:extra-fields r)))))
+    (testing "directory entry is recognised"
+      (is (true? (:directory? dir)))
+      (is (contains? (:dos-attributes dir) :directory)))
+    (testing "unix-mode decoded as expected octal"
+      (is (= 040755 (:unix-mode dir))) ; rwxr-xr-x directory
+      (is (= 0100644 (:unix-mode file))))
+    (testing "non-archive comment, non-encrypted, ASCII"
+      (is (false? (:encrypted? file)))
+      (is (false? (:utf8-name? file))))
+    (testing "extended-timestamp extra-field is decoded"
+      (let [ts (some #(when (= :extended-timestamp (:tag-name %)) %)
+                     (:extra-fields file))]
+        (is (some? ts))
+        (is (integer? (-> ts :decoded :mtime)))))))
+
+(deftest zip-meta-decode-false-skips-decoration
+  (let [r (first (:cdr-records (zm/zip-meta good-file {:decode false})))]
+    (is (not (contains? (:record r) :last-modified)))
+    (is (not (contains? (:record r) :dos-attributes)))
+    (is (not (contains? (:record r) :unix-mode)))
+    (is (not (contains? (:record r) :extra-fields)))))
 
 (deftest set-zip-comment-rejects-over-65535-bytes
   (let [tmp (copy-to-tmp good-file "comment-big-")]

--- a/src/test/clj_zip_meta/core_test.clj
+++ b/src/test/clj_zip_meta/core_test.clj
@@ -191,6 +191,13 @@
     (is (= "hello, comment!" (zm/zip-comment tmp)))
     (is (true? (:valid? (zm/validate-zip-meta tmp))))))
 
+(deftest verify-crcs-passes-on-intact-archive
+  (let [results (zm/verify-crcs good-file)
+        summary (zm/verify-crcs-summary good-file)]
+    (is (every? #{:ok :empty} (map :status results)))
+    (is (true? (:valid? summary)))
+    (is (zero? (count (:mismatches summary))))))
+
 (deftest cdr-records-have-decoded-convenience-keys
   (let [recs (->> (zm/zip-meta good-file) :cdr-records (mapv :record))
         dir  (first (filter :directory? recs))
@@ -257,6 +264,41 @@
   (let [path (write-test-zip {"alpha.txt" "a" "beta.txt" "b" "gamma.txt" "g"})]
     (is (= "beta.txt" (:file-name (zm/find-entry path "beta.txt"))))
     (is (nil? (zm/find-entry path "nope.txt")))))
+
+(deftest verify-crcs-detects-tampering
+  ;; Build a real zip, then flip a byte inside the compressed payload
+  ;; of one entry. The CRC should no longer match.
+  (let [path (write-test-zip {"hello.txt" "the quick brown fox jumps over the lazy dog"
+                              "two.txt"   "two"})
+        m    (zm/zip-meta path)
+        ;; ZipOutputStream uses data descriptors, so the LFH carries
+        ;; zero sizes. Use the CDR's authoritative :compressed-size
+        ;; and pair it with the matching LFH offset from
+        ;; :local-records.
+        cdr-rec (first (filter #(pos? (long (-> % :record :compressed-size)))
+                                (:cdr-records m)))
+        cdr     (:record cdr-rec)
+        lfh-rec (some #(when (= (-> % :record :file-name) (:file-name cdr)) %)
+                       (:local-records m))
+        lfh     (:record lfh-rec)
+        data-off (+ (long (:offset lfh-rec))
+                    30
+                    (bit-and 0xFFFF (long (:file-name-length lfh)))
+                    (bit-and 0xFFFF (long (:extra-field-length lfh))))]
+    (with-open [r (RandomAccessFile. path "rw")]
+      (.seek r data-off)
+      (let [b (.readByte r)]
+        (.seek r data-off)
+        (.writeByte r (bit-xor (int b) 0xFF))))
+    (let [results (zm/verify-crcs path)
+          summary (zm/verify-crcs-summary path)]
+      (is (false? (:valid? summary)))
+      ;; Flipping a byte inside a deflate stream usually makes the
+      ;; stream itself unparseable, which surfaces as :error from the
+      ;; inflater. On the off chance the bit happens to land in a
+      ;; non-load-bearing position the bytes still inflate but the
+      ;; CRC will mismatch. Either outcome counts as detection.
+      (is (some #(contains? #{:mismatch :error} (:status %)) results)))))
 
 (deftest creates-and-parses-a-test-zip
   (let [path (write-test-zip {"a.txt" "alpha" "b.txt" "bravo"})

--- a/src/test/clj_zip_meta/core_test.clj
+++ b/src/test/clj_zip_meta/core_test.clj
@@ -191,6 +191,30 @@
     (is (= "hello, comment!" (zm/zip-comment tmp)))
     (is (true? (:valid? (zm/validate-zip-meta tmp))))))
 
+(deftest round-trip-rewrite-preserves-everything
+  ;; A no-op repair-zip-with-preamble-bytes (extra-bytes = 0) should
+  ;; leave the file byte-identical, but more interestingly: a repair on
+  ;; an archive with preamble bytes should still produce something that
+  ;; zip-meta parses to a structurally identical CDR (same offsets and
+  ;; primitive fields) after the round trip.
+  (let [tmp     (copy-to-tmp bad-prelude-file "round-trip-")
+        before  (zm/zip-meta tmp {:decode false})]
+    (zm/repair-zip-with-preamble-bytes tmp)
+    (let [after (zm/zip-meta tmp {:decode false})]
+      (is (= 0 (:extra-bytes after)))
+      (is (= (count (:cdr-records before))
+             (count (:cdr-records after))))
+      ;; Primitive fields preserved (the offsets bumped by extra-bytes).
+      (let [extra 317]
+        (doseq [[b a] (map vector (:cdr-records before) (:cdr-records after))]
+          (let [br (:record b) ar (:record a)]
+            (is (= (:file-name br)         (:file-name ar)))
+            (is (= (:crc-32 br)            (:crc-32 ar)))
+            (is (= (:compressed-size br)   (:compressed-size ar)))
+            (is (= (:uncompressed-size br) (:uncompressed-size ar)))
+            (is (= (+ extra (long (:relative-offset-local-header br)))
+                   (:relative-offset-local-header ar)))))))))
+
 (deftest verify-crcs-passes-on-intact-archive
   (let [results (zm/verify-crcs good-file)
         summary (zm/verify-crcs-summary good-file)]


### PR DESCRIPTION
## Summary

A perf + completeness pass on top of 0.2.0. Six focused commits:

1. **Hand-rolled fast reader** replaces `octet`'s protocol-dispatch path. `zip-meta` on `clojure-1.12.0.jar` (3 770 entries) drops from **1 893 ms → 12 ms** (raw) / **25 ms** (with decoded keys).
2. **Decoded convenience keys** on every record: `:last-modified` (`LocalDateTime`), `:dos-attributes` (set), `:unix-mode` (octal), `:directory?`, `:encrypted?`, `:utf8-name?`, `:extra-fields` (parsed TLV vector with a decoder for extended-timestamp). Pass `{:decode false}` to skip.
3. **CRC-32 verification** of entry contents — `verify-crcs`, `verify-crcs-summary`, `:verify-crcs` keyword on `validate-zip-meta`, and a `verify` CLI command. Supports STORED and DEFLATE; reports `:ok`, `:mismatch`, `:empty`, `:unsupported-method`, `:error` per entry.
4. **Hand-rolled writers** mirror the readers — `repair-zip-with-preamble-bytes`, `rebuild-central-directory!`, `set-zip-comment!` are now octet-free on the write side too. Octet remains only for the legacy public `read-spec-from-*` / `write-spec-to-*` wrappers.
5. **`deps.edn`** with `:test`, `:cli`, `:bench` aliases. **`bench/clj_zip_meta/bench.clj`** runs criterium quick-benches against the hot paths. `find-entry` looks up a single entry by name. `zip-meta` accepts `{:include-locals false}` to skip the per-entry LFH reads.
6. **CLI**: `verify` command, `--crc` flag on `validate`, `--json` flag on every read-only command (inline JSON emitter, no new dependency), `--version` flag.

## Benchmarks (clojure-1.12.0.jar, 3 770 entries)

|                              | 0.2.0     | 0.3.0 raw | 0.3.0 decoded |
| ---------------------------- | --------- | --------- | ------------- |
| `zip-meta` (full)            | 1 893 ms  |    12 ms  |        25 ms  |
| `zip-meta` (CDR only)        | 1 198 ms  |     5 ms  |        14 ms  |
| `zip-entries`                | 1 225 ms  |     —     |        18 ms  |
| `find-end-of-cdr-offset`     |     —     |     —     |        16 µs  |
| `verify-crcs`                |     —     |     —     |        40 ms  |

## Test plan

- [x] `lein test` clean (39 tests / 155 assertions)
- [x] `lein check` reports no reflection warnings from `clj_zip_meta.*`
- [x] `lein bench` runs end-to-end
- [x] CLI smoke test: list / meta / summary / comment / validate / verify / repair / --json / --version
- [ ] CI matrix